### PR TITLE
Replace "Traffic generation" header with "Rewards for high-uptime nodes"

### DIFF
--- a/reward-program/README.md
+++ b/reward-program/README.md
@@ -116,5 +116,5 @@ Stage 2 of stateless validation StatelessNet.
 ## Additional reward for top N participants
 The top five participants, based on a number of valid reports and proposals, will get additional reward for their active participation.
 
-## Traffic generation
+## Rewards for high-uptime nodes
 In Stage 2 of the program existing mainnet validators who are running a node in StatelessNet with high uptime are eligible to be rewarded. More details will be shared soon.


### PR DESCRIPTION
The section of rewards readme that contains information about high-uptime nodes is titled "Traffic generation". This is pretty confusing, as those are two separate things. Let's change the title to "Rewards for high-uptime nodes"